### PR TITLE
Make stale events loop permissive on the actual event type

### DIFF
--- a/internal/github/checkStalePRs.go
+++ b/internal/github/checkStalePRs.go
@@ -83,9 +83,9 @@ func isStale(ctx context.Context, githubClient *github.Client, pr *github.PullRe
 			return false, err
 		}
 		for _, event := range events {
-			if event.Event == nil || (*event.Event != "commented" && *event.Event != "reviewed") {
+			if event.Event == nil {
 				if event.ID != nil {
-					slogs.Logr.Warn("Event is neither of type COMMENTED or REVIEWED, or it might be nil. Cannot process event", "PR", pr.GetNumber(), "repository", pr.Base.Repo.GetName(), "event", *event.ID)
+					slogs.Logr.Warn("Event does not specify any of the known event types, nil event type. Cannot process event", "PR", pr.GetNumber(), "repository", pr.Base.Repo.GetName(), "event", *event.ID)
 				}
 				continue
 			}


### PR DESCRIPTION
Still skips the event if `event.Event` is nil just to make sure the event is at least _one of_ the event types from this list https://docs.github.com/en/rest/using-the-rest-api/issue-event-types?apiVersion=2022-11-28

This check doesn't really make sure it's one of those listed event types so much that _an_ event type is specified.